### PR TITLE
fix: 파일 확장자 차단에서 deleteAPI 수정 

### DIFF
--- a/backend/src/main/java/com/test/extensionblock/repository/ExtensionRepository.java
+++ b/backend/src/main/java/com/test/extensionblock/repository/ExtensionRepository.java
@@ -9,4 +9,6 @@ public interface ExtensionRepository extends JpaRepository<Extension, Long> {
     Extension findByExtensionName(String extensionName);
 
     Long countByType(String type);
+
+    void deleteByExtensionName(String extensionName);
 }

--- a/backend/src/main/java/com/test/extensionblock/service/ExtensionService.java
+++ b/backend/src/main/java/com/test/extensionblock/service/ExtensionService.java
@@ -10,6 +10,7 @@ import com.test.extensionblock.repository.ExtensionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import java.util.List;
@@ -36,11 +37,12 @@ public class ExtensionService {
         return extensionRepository.save(newBlockExtension);
     }
 
+
+    @Transactional
     public void deleteBlockFixedExtension(String extensionName) {
         validateFixedExtensionName(extensionName);
-
-        Extension deletedBlockExtension = Extension.createFixedExtension(extensionName);
-        extensionRepository.delete(deletedBlockExtension);
+        checkFixedExtensionNameDeletePolicy(extensionName);
+        extensionRepository.deleteByExtensionName(extensionName);
     }
 
     private void validateFixedExtensionName(String extensionName) {
@@ -57,12 +59,11 @@ public class ExtensionService {
         return extensionRepository.save(newBlockExtension);
     }
 
+    @Transactional
     public void deleteBlockCustomExtension(String extensionName) {
         validateCustomExtensionName(extensionName);
         checkCustomExtensionNameDeletePolicy(extensionName);
-
-        Extension deletedBlockExtension = Extension.createCustomExtension(extensionName);
-        extensionRepository.delete(deletedBlockExtension);
+        extensionRepository.deleteByExtensionName(extensionName);
     }
 
 

--- a/backend/src/main/java/com/test/extensionblock/service/ExtensionService.java
+++ b/backend/src/main/java/com/test/extensionblock/service/ExtensionService.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class ExtensionService {
 
     final Long maxlengthLimit = 20L;
-    final List<String> blockFixedExtensionList = List.of("bat", "cmd", "com" ,"cpl", "exe", "scr", "js");
+    final List<String> blockFixedExtensionList = List.of("bat", "cmd", "com", "cpl", "exe", "scr", "js");
 
     @Autowired
     private Validator validator;
@@ -32,11 +32,23 @@ public class ExtensionService {
 
     public Extension addBlockFixedExtension(String extensionName) {
         validateFixedExtensionName(extensionName);
+        checkFixedExtensionNameCreatePolicy(extensionName);
 
         Extension newBlockExtension = Extension.createFixedExtension(extensionName);
         return extensionRepository.save(newBlockExtension);
     }
 
+    private void validateFixedExtensionName(String extensionName) {
+        if (!blockFixedExtensionList.contains(extensionName)) {
+            throw new ExtensionNameValidationException(extensionName + " is not fixed extension");
+        }
+    }
+
+    private void checkFixedExtensionNameCreatePolicy(String extensionName) {
+        if (extensionRepository.findByExtensionName(extensionName) != null) {
+            throw new ExtensionNameDuplicateException("extension is already block");
+        }
+    }
 
     @Transactional
     public void deleteBlockFixedExtension(String extensionName) {
@@ -45,9 +57,9 @@ public class ExtensionService {
         extensionRepository.deleteByExtensionName(extensionName);
     }
 
-    private void validateFixedExtensionName(String extensionName) {
-        if(!blockFixedExtensionList.contains(extensionName)) {
-            throw new ExtensionNameValidationException(extensionName + " is not fixed extension");
+    private void checkFixedExtensionNameDeletePolicy(String extensionName) {
+        if (extensionRepository.findByExtensionName(extensionName) == null) {
+            throw new ExtensionNameNotExistedException("extension is not block");
         }
     }
 
@@ -65,8 +77,6 @@ public class ExtensionService {
         checkCustomExtensionNameDeletePolicy(extensionName);
         extensionRepository.deleteByExtensionName(extensionName);
     }
-
-
 
 
     private void validateCustomExtensionName(String extensionName) {
@@ -87,22 +97,22 @@ public class ExtensionService {
         }
 
     }
+
     private void checkCustomExtensionNameCreatePolicy(String extensionName) {
-
         if (extensionRepository.findByExtensionName(extensionName) != null) {
-            throw new ExtensionNameDuplicateException("extension is duplicated");
+            throw new ExtensionNameDuplicateException("extension is already block");
         }
-
-        if(extensionRepository.countByType("custom") >= maxlengthLimit) {
+        if (extensionRepository.countByType("custom") >= maxlengthLimit) {
             throw new ExtensionCountMaxException(maxlengthLimit);
         }
     }
+
+
     private void checkCustomExtensionNameDeletePolicy(String extensionName) {
         if (extensionRepository.findByExtensionName(extensionName) == null) {
-            throw new ExtensionNameNotExistedException("extension is not existed");
+            throw new ExtensionNameNotExistedException("extension is not block");
         }
-
-        if(extensionRepository.countByType("custom") >= maxlengthLimit) {
+        if (extensionRepository.countByType("custom") >= maxlengthLimit) {
             throw new ExtensionCountMaxException(maxlengthLimit);
         }
     }


### PR DESCRIPTION
## Summary
파일 확장자 차단에서 deleteAPI를 수정합니다.

## Description
- extensionName으로 했어야 했는데 기본 delete 메서드를 사용해서 이부분 수정합니다.
- jpa에서 delete시에는 transaction을 붙여야 하는데 이부분을 수정합니다. 
- 고정 확장자의 경우 반복되는 요청이 되었을 때 확인하는 로직이 없었는데 이부분을 추가 합니다. 
